### PR TITLE
DGD-4258 DGD-4311 Events emission enhancements

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
@@ -77,7 +77,7 @@ public class NuEventEmitter {
                     .forEach(dataset -> {
                         try {
                             log.debug("Discarding column lineage facet for dataset {} {} {}",
-                                    dataset.getClass().getName(), dataset.getNamespace(), dataset.getName());
+                                    dataset.getClass().getSimpleName(), dataset.getNamespace(), dataset.getName());
                             columnLineageFacetField.set(dataset.getFacets(), null);
                         } catch (IllegalAccessException e) {
                             log.error("Failed to discard column lineage facet", e);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
@@ -28,7 +28,7 @@ public class NuEventEmitter {
     private static Boolean isPermittedJobType(RunEvent event) {
         String jobType = event.getJob().getFacets().getJobType().getJobType();
         if (WANTED_JOB_TYPES.stream().noneMatch(jobType::equals)) {
-            log.info("OpenLineage event with job type {} has no lineage value and should not be emitted", jobType);
+            log.debug("OpenLineage event with job type {} has no lineage value and should not be emitted", jobType);
             return false;
         }
         return true;
@@ -36,7 +36,7 @@ public class NuEventEmitter {
 
     private static Boolean isPermitedEventType(RunEvent event) {
         if (RUNNING.equals(event.getEventType())) {
-            log.info("OpenLineage event is {} and should not be emitted", RUNNING);
+            log.debug("OpenLineage event is {} and should not be emitted", RUNNING);
             return false;
         }
         return true;
@@ -45,11 +45,11 @@ public class NuEventEmitter {
     private static Boolean isPermittedJobName(RunEvent event) {
         String jobName = event.getJob().getName();
         if (isNull(jobName)) {
-            log.info("OpenLineage event has no job name and should not be emitted");
+            log.debug("OpenLineage event has no job name and should not be emitted");
             return false;
         }
         if (WANTED_EVENT_NAME_SUBSTRINGS.stream().noneMatch(jobName::contains)) {
-            log.info("OpenLineage event job name has no permitted substring and should not be emitted");
+            log.debug("OpenLineage event job name has no permitted substring and should not be emitted");
             return false;
         }
         return true;
@@ -76,11 +76,11 @@ public class NuEventEmitter {
                     .collect(Collectors.toList())
                     .forEach(dataset -> {
                         try {
-                            log.info("Discarding column lineage facet for dataset {} {} {}",
+                            log.debug("Discarding column lineage facet for dataset {} {} {}",
                                     dataset.getClass().getName(), dataset.getNamespace(), dataset.getName());
                             columnLineageFacetField.set(dataset.getFacets(), null);
                         } catch (IllegalAccessException e) {
-                            log.warn("Failed to discard column lineage facet", e);
+                            log.error("Failed to discard column lineage facet", e);
                         }
                     });
         } catch (NoSuchFieldException e) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java
@@ -1,0 +1,102 @@
+package io.openlineage.spark.agent;
+
+import io.openlineage.client.OpenLineage;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.openlineage.client.OpenLineage.RunEvent.EventType;
+import static io.openlineage.client.OpenLineage.RunEvent;
+import static io.openlineage.client.OpenLineage.RunEvent.EventType.*;
+import static java.util.Objects.isNull;
+
+@Slf4j
+public class NuEventEmitter {
+
+    private static final Set<String> WANTED_JOB_TYPES = Set.of(
+            "SQL_JOB" // as defined in SparkSQLExecutionContext.SPARK_JOB_TYPE
+    );
+
+    private static final Set<String> WANTED_EVENT_NAME_SUBSTRINGS = Set.of(
+            ".execute_insert_into_hadoop_fs_relation_command.",
+            ".adaptive_spark_plan."
+    );
+
+    private static Boolean isPermittedJobType(RunEvent event) {
+        String jobType = event.getJob().getFacets().getJobType().getJobType();
+        if (WANTED_JOB_TYPES.stream().noneMatch(jobType::equals)) {
+            log.info("OpenLineage event with job type {} has no lineage value and should not be emitted", jobType);
+            return false;
+        }
+        return true;
+    }
+
+    private static Boolean isPermitedEventType(RunEvent event) {
+        if (RUNNING.equals(event.getEventType())) {
+            log.info("OpenLineage event is {} and should not be emitted", RUNNING);
+            return false;
+        }
+        return true;
+    }
+
+    private static Boolean isPermittedJobName(RunEvent event) {
+        String jobName = event.getJob().getName();
+        if (isNull(jobName)) {
+            log.info("OpenLineage event has no job name and should not be emitted");
+            return false;
+        }
+        if (WANTED_EVENT_NAME_SUBSTRINGS.stream().noneMatch(jobName::contains)) {
+            log.info("OpenLineage event job name has no permitted substring and should not be emitted");
+            return false;
+        }
+        return true;
+    }
+
+    private static Boolean shouldEmit(RunEvent event) {
+        return Stream.of(
+                isPermittedJobType(event),
+                isPermitedEventType(event),
+                isPermittedJobName(event)
+        ).noneMatch(Boolean.FALSE::equals);
+    }
+
+    private static Boolean shouldDiscardColumnLineageFacet(EventType eventType) {
+        return !COMPLETE.equals(eventType);
+    }
+
+    private static void discardColumnLineageFacet(RunEvent event) {
+        try {
+            Field columnLineageFacetField = OpenLineage.DatasetFacets.class.getDeclaredField("columnLineage");
+            columnLineageFacetField.setAccessible(true);
+            Stream
+                    .concat(event.getInputs().stream(), event.getOutputs().stream())
+                    .collect(Collectors.toList())
+                    .forEach(dataset -> {
+                        try {
+                            log.info("Discarding column lineage facet for dataset {} {} {}",
+                                    dataset.getClass().getName(), dataset.getNamespace(), dataset.getName());
+                            columnLineageFacetField.set(dataset.getFacets(), null);
+                        } catch (IllegalAccessException e) {
+                            log.warn("Failed to discard column lineage facet", e);
+                        }
+                    });
+        } catch (NoSuchFieldException e) {
+            log.error("Failed to discard column lineage facet: columnLineage field not found at OpenLineage.DatasetFacets", e);
+        }
+    }
+
+    public static void emit(RunEvent event, EventEmitter eventEmitter) {
+        if (!shouldEmit(event)) {
+            return;
+        }
+
+        if (shouldDiscardColumnLineageFacet(event.getEventType())) {
+            discardColumnLineageFacet(event);
+        }
+
+        eventEmitter.emit(event);
+    }
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.NuEventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.facets.ErrorFacet;
 import io.openlineage.spark.agent.facets.builder.GcpJobFacetBuilder;
@@ -225,10 +226,8 @@ class RddExecutionContext implements ExecutionContext {
             .job(buildJob(jobStart.jobId()))
             .build();
 
-    log.info("OpenLineage {} event has no lineage value an will not be emmited", SPARK_JOB_TYPE);
-
-//    log.debug("Posting event for start {}: {}", jobStart, event);
-//    eventEmitter.emit(event);
+    log.debug("Posting event for start {}: {}", jobStart, event);
+    NuEventEmitter.emit(event, eventEmitter);
   }
 
   @Override
@@ -261,10 +260,8 @@ class RddExecutionContext implements ExecutionContext {
             .job(buildJob(jobEnd.jobId()))
             .build();
 
-    log.info("OpenLineage {} event has no lineage value an will not be emmited", SPARK_JOB_TYPE);
-
-//    log.debug("Posting event for end {}: {}", jobEnd, event);
-//    eventEmitter.emit(event);
+    log.debug("Posting event for end {}: {}", jobEnd, event);
+    NuEventEmitter.emit(event, eventEmitter);
   }
 
   protected OpenLineage.RunFacets buildRunFacets(ErrorFacet jobError, SparkListenerEvent event) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -224,8 +224,11 @@ class RddExecutionContext implements ExecutionContext {
                     .build())
             .job(buildJob(jobStart.jobId()))
             .build();
-    log.debug("Posting event for start {}: {}", jobStart, event);
-    eventEmitter.emit(event);
+
+    log.info("OpenLineage {} event has no lineage value an will not be emmited", SPARK_JOB_TYPE);
+
+//    log.debug("Posting event for start {}: {}", jobStart, event);
+//    eventEmitter.emit(event);
   }
 
   @Override
@@ -257,8 +260,11 @@ class RddExecutionContext implements ExecutionContext {
                     .build())
             .job(buildJob(jobEnd.jobId()))
             .build();
-    log.debug("Posting event for end {}: {}", jobEnd, event);
-    eventEmitter.emit(event);
+
+    log.info("OpenLineage {} event has no lineage value an will not be emmited", SPARK_JOB_TYPE);
+
+//    log.debug("Posting event for end {}: {}", jobEnd, event);
+//    eventEmitter.emit(event);
   }
 
   protected OpenLineage.RunFacets buildRunFacets(ErrorFacet jobError, SparkListenerEvent event) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -94,8 +94,11 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                 .event(applicationStart)
                 .build());
 
-    log.debug("Posting event for applicationId {} start: {}", applicationId, event);
-    eventEmitter.emit(event);
+
+    log.info("OpenLineage APPLICATION event has no lineage value an will not be emmited");
+
+//    log.debug("Posting event for applicationId {} start: {}", applicationId, event);
+//    eventEmitter.emit(event);
   }
 
   @Override
@@ -125,8 +128,10 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                 .event(applicationEnd)
                 .build());
 
-    log.debug("Posting event for applicationId {} end: {}", applicationId, event);
-    eventEmitter.emit(event);
+    log.info("OpenLineage APPLICATION event has no lineage value an will not be emmited");
+
+//    log.debug("Posting event for applicationId {} end: {}", applicationId, event);
+//    eventEmitter.emit(event);
   }
 
   private OpenLineage.ParentRunFacet buildApplicationParentFacet() {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -12,6 +12,7 @@ import static io.openlineage.spark.agent.util.TimeUtils.toZonedTime;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.NuEventEmitter;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.naming.JobNameBuilder;
@@ -94,11 +95,8 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                 .event(applicationStart)
                 .build());
 
-
-    log.info("OpenLineage APPLICATION event has no lineage value an will not be emmited");
-
-//    log.debug("Posting event for applicationId {} start: {}", applicationId, event);
-//    eventEmitter.emit(event);
+    log.debug("Posting event for applicationId {} start: {}", applicationId, event);
+    NuEventEmitter.emit(event, eventEmitter);
   }
 
   @Override
@@ -128,10 +126,8 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                 .event(applicationEnd)
                 .build());
 
-    log.info("OpenLineage APPLICATION event has no lineage value an will not be emmited");
-
-//    log.debug("Posting event for applicationId {} end: {}", applicationId, event);
-//    eventEmitter.emit(event);
+    log.debug("Posting event for applicationId {} end: {}", applicationId, event);
+    NuEventEmitter.emit(event, eventEmitter);
   }
 
   private OpenLineage.ParentRunFacet buildApplicationParentFacet() {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -43,7 +43,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
   private static final String SPARK_PROCESSING_TYPE_BATCH = "BATCH";
   private static final String SPARK_PROCESSING_TYPE_STREAMING = "STREAMING";
   private final long executionId;
-  private String jobName;
   private final OpenLineageContext olContext;
   private final EventEmitter eventEmitter;
   private final OpenLineageRunEventBuilder runEventBuilder;
@@ -81,9 +80,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
           "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionStart");
       // return;
     }
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
     olContext.setActiveJobId(activeJobId);
-    // We shall skip this START event, focusing on the first SparkListenerJobStart event to be the START, because of the presence of the job nurn
     // only one START event is expected, in case it was already sent with jobStart, we send running
      EventType eventType = emittedOnJobStart ? RUNNING : START;
      emittedOnSqlExecutionStart = true;
@@ -129,7 +126,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
           "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
       // return;
     }
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
     // only one COMPLETE event is expected, verify if jobEnd was not emitted
     EventType eventType;
     if (emittedOnJobStart && !emittedOnJobEnd) {
@@ -178,7 +174,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
           "OpenLineage received Spark event that is configured to be skipped: SparkListenerStageSubmitted");
       return;
     }
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
     RunEvent event =
         runEventBuilder.buildRun(
             OpenLineageRunEventContext.builder()
@@ -210,7 +205,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
           "OpenLineage received Spark event that is configured to be skipped: SparkListenerStageCompleted");
       return;
     }
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
     RunEvent event =
         runEventBuilder.buildRun(
             OpenLineageRunEventContext.builder()
@@ -251,13 +245,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public void start(SparkListenerJobStart jobStart) {
     log.debug("SparkListenerJobStart - executionId: {}", executionId);
-//    try {
-//      jobName = jobStart.properties().getProperty("spark.job.name");
-//    } catch (RuntimeException e) {
-//      log.info("spark.job.name property not found in the context");
-//    }
-
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
@@ -270,7 +257,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
     // only one START event is expected, in case it was already sent with sqlExecutionStart, we send
     // running
     EventType eventType = emittedOnSqlExecutionStart ? RUNNING : START;
-//    emittedOnSqlExecutionStart = true;
     emittedOnJobStart = true;
 
     RunEvent event =
@@ -314,8 +300,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
           "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobEnd");
       // return;
     }
-
-//    olContext.setJobNurn(olContext.getSparkSession().get().conf().get("spark.job.name"));
 
     // only one COMPLETE event is expected,
     EventType eventType;

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -57,11 +57,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   private SparkSQLQueryParser sqlRecorder = new SparkSQLQueryParser();
 
-//  private static final Set<String> NU_WANTED_EVENT_NAME_SUBSTRINGS = Set.of(
-//          ".execute_insert_into_hadoop_fs_relation_command.",
-//          ".adaptive_spark_plan."
-//  );
-
   public SparkSQLExecutionContext(
       long executionId,
       EventEmitter eventEmitter,

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -25,11 +25,20 @@ import io.openlineage.spark.api.naming.JobNameBuilder;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Stack;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.spark.scheduler.*;
+import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.JobFailed;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/NuFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/NuFacet.java
@@ -8,13 +8,18 @@ package io.openlineage.spark.agent.facets;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+
+import java.util.NoSuchElementException;
 import java.util.Properties;
 import lombok.Getter;
 import lombok.NonNull;
 import io.openlineage.spark.api.OpenLineageContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
 
 /** Captures information related to the Apache Spark job. */
 @Getter
+@Slf4j
 public class NuFacet extends OpenLineage.DefaultRunFacet {
   // @JsonProperty("jobId")
   // @NonNull
@@ -26,8 +31,24 @@ public class NuFacet extends OpenLineage.DefaultRunFacet {
   @JsonProperty("jobNurn")
   private String jobNurn;
 
+  private String fetchJobNurn(OpenLineageContext olContext) {
+    if (olContext.getSparkSession().isPresent()) {
+      SparkSession sparkSession = olContext.getSparkSession().get();
+      try {
+        return sparkSession.conf().get("spark.job.name");
+      } catch (NoSuchElementException e) {
+        log.warn("spark.job.name property not found in the context");
+        return null;
+      }
+    }
+
+    log.warn("spark.job.name property not found because the SparkContext could not be retrieved from OpenLineageContext");
+    return null;
+  }
+
   public NuFacet(@NonNull OpenLineageContext olContext) {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
-    this.jobNurn = olContext.getJobNurn();
+    this.jobNurn = fetchJobNurn(olContext);
+//    this.jobNurn = olContext.getJobNurn();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/NuFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/NuFacet.java
@@ -49,6 +49,5 @@ public class NuFacet extends OpenLineage.DefaultRunFacet {
   public NuFacet(@NonNull OpenLineageContext olContext) {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
     this.jobNurn = fetchJobNurn(olContext);
-//    this.jobNurn = olContext.getJobNurn();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -132,12 +132,6 @@ public class OpenLineageContext {
    */
   @Getter @Setter String jobName;
 
-  /**
-   * Job nurn is collected during the Spark runs, and stored for creating a custom facet within
-   * the Run facets. It should help us to enhance the events further in the lineage pipeline.
-   */
-  @Getter @Setter String jobNurn;
-
   @Setter Integer activeJobId;
 
   public Optional<Integer> getActiveJobId() {


### PR DESCRIPTION
This pull request introduces a significant refactor to the event emission logic in the Spark agent, focusing on the introduction of a new `NuEventEmitter` class. The changes aim to improve the filtering and handling of OpenLineage events.

### Introduction of `NuEventEmitter`:

* [`integration/spark/app/src/main/java/io/openlineage/spark/agent/NuEventEmitter.java`](diffhunk://#diff-8d45877447a995af9c19637418ff2bf18f4cde3c12cb1a53f0872d4c0345f80cR1-R102): Added the `NuEventEmitter` class, which includes methods to filter events based on job type, event type, and job name, and to discard column lineage facets for non-complete events.

### Refactoring event emission:

* [`integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java`](diffhunk://#diff-98bf81eb894992d79c46d5f2dbed74083258c4ede991a4198fba74352cf3a433R14): Replaced direct calls to `eventEmitter.emit` with `NuEventEmitter.emit` in the `start` and `end` methods for `SparkListenerJobStart` and `SparkListenerJobEnd` events. [[1]](diffhunk://#diff-98bf81eb894992d79c46d5f2dbed74083258c4ede991a4198fba74352cf3a433R14) [[2]](diffhunk://#diff-98bf81eb894992d79c46d5f2dbed74083258c4ede991a4198fba74352cf3a433R228-R230) [[3]](diffhunk://#diff-98bf81eb894992d79c46d5f2dbed74083258c4ede991a4198fba74352cf3a433R262-R264)
* [`integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java`](diffhunk://#diff-f9655525d41f1f278a0f9c1f9fef2a9f2d4d5c0f370e0afe41836f660f6dd4aeR15): Updated the `start` and `end` methods for `SparkListenerApplicationStart` and `SparkListenerApplicationEnd` events to use `NuEventEmitter.emit`. [[1]](diffhunk://#diff-f9655525d41f1f278a0f9c1f9fef2a9f2d4d5c0f370e0afe41836f660f6dd4aeR15) [[2]](diffhunk://#diff-f9655525d41f1f278a0f9c1f9fef2a9f2d4d5c0f370e0afe41836f660f6dd4aeL98-R99) [[3]](diffhunk://#diff-f9655525d41f1f278a0f9c1f9fef2a9f2d4d5c0f370e0afe41836f660f6dd4aeL129-R130)
* [`integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java`](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339R19-R32): Applied similar changes to use `NuEventEmitter.emit` for various event methods, including `start` and `end` for `SparkListenerSQLExecutionStart`, `SparkListenerSQLExecutionEnd`, `SparkListenerStageSubmitted`, and `SparkListenerStageCompleted` events. [[1]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339R19-R32) [[2]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L91-R110) [[3]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L163-R159) [[4]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L194-R190) [[5]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L224-R220) [[6]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L247-L252) [[7]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L265) [[8]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L284-R273) [[9]](diffhunk://#diff-53ec809ef02bec7810c0cdac69c8bac119f275a0ac091fe83d5559e078505339L333-R322)

### Enhancements to `NuFacet`:

* [`integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/NuFacet.java`](diffhunk://#diff-f873b76af2b15c63021ec4e0d8fdf3e02c8ac0d62548fbfaf15f440f811cff62R11-R22): Implemented a method to fetch the job name (`jobNurn`) from the Spark session configuration, adding logging for cases where the job name is not found. [[1]](diffhunk://#diff-f873b76af2b15c63021ec4e0d8fdf3e02c8ac0d62548fbfaf15f440f811cff62R11-R22) [[2]](diffhunk://#diff-f873b76af2b15c63021ec4e0d8fdf3e02c8ac0d62548fbfaf15f440f811cff62R34-R51)

### Removal of unused fields:

* [`integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java`](diffhunk://#diff-ed5714b8f30a18a35dcaf1daf715fa54d4e0d8c996ab6590ee324ee8fe8ec5dfL135-L140): Removed the `jobNurn` field, which is now dynamically fetched in `NuFacet`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [X] Non-breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes