### PR TITLE
Updates in spark-agent build process

### DIFF
--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -169,10 +169,11 @@ publishing {
                 }
             }
 
-            pom.withXml {
-                Node pomNode = asNode()
-                pomNode.remove(pomNode.get("dependencies"))
-            }
+            // -------- removing the following section to enable the dependencies within the pom file --------
+            // pom.withXml {
+            //     Node pomNode = asNode()
+            //     pomNode.remove(pomNode.get("dependencies"))
+            // }
         }
     }
 

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -141,6 +141,7 @@ publishing {
 
             artifact sourceJar
             artifact javadocJar
+            artifact shadowJarWithoutExternalDependencies
 
             pom {
                 name = "openlineage-spark_${scala}"

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -47,58 +47,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-task shadowJarWithoutExternalDependencies(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-    archiveClassifier.set('without-external-dependencies')
-    configurations = [project.configurations.runtimeClasspath]
-    minimize() {
-        exclude(project(path: ":app"))
-        exclude(project(path: ":shared", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":spark2"))
-        exclude(project(path: ":spark3", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":spark31"))
-        exclude(project(path: ":spark32", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":spark33", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":spark34", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
-        exclude(project(path: ":snowflake"))
-    }
-
-    dependencies {
-        exclude(dependency("org.slf4j::"))
-        exclude("org/apache/commons/logging/**")
-        exclude("io/openlineage/server/**")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_x86_64.so")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_aarch64.so")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_arm64.dylib")
-        exclude("com/fasterxml/jackson/**")
-        exclude("org/apache/http/**")
-        exclude("org/apache/httpcomponents/client5/**")
-        exclude("com/github/ok2c/hc5/**")
-        exclude("org/apache/hc/**")
-        exclude("org/HdrHistogram/**")
-        exclude("org/LatencyUtils/**")
-        exclude("org/apache/commons/codec/**")
-        exclude("org/apache/commons/lang3/**")
-        exclude("org/apache/commons/beanutils/**")
-        exclude("org/yaml/snakeyaml/**")
-        exclude("javassist/**")
-        exclude("io/micrometer/**")
-        exclude("mozilla/**")
-        exclude("org/publicsuffix/**")
-    }
-
-    manifest {
-        attributes(
-                "Created-By": "Gradle ${gradle.gradleVersion}",
-                "Built-By": System.getProperty("user.name"),
-                "Build-Jdk": System.getProperty("java.version"),
-                "Implementation-Title": project.name,
-                "Implementation-Version": project.version
-        )
-    }
-    zip64 true
-}
-
 javadoc {
     options.tags = ["apiNote"]
 }
@@ -141,7 +89,6 @@ publishing {
 
             artifact sourceJar
             artifact javadocJar
-            artifact shadowJarWithoutExternalDependencies
 
             pom {
                 name = "openlineage-spark_${scala}"

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -168,20 +168,38 @@ shadowJar {
         exclude(dependency("org.slf4j::"))
         exclude("org/apache/commons/logging/**")
         exclude("io/openlineage/server/**")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_x86_64.so")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_aarch64.so")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_arm64.dylib")
+        exclude("com/fasterxml/jackson/**")
+        exclude("org/apache/http/**")
+        exclude("org/apache/httpcomponents/client5/**")
+        exclude("com/github/ok2c/hc5/**")
+        exclude("org/apache/hc/**")
+        exclude("org/HdrHistogram/**")
+        exclude("org/LatencyUtils/**")
+        exclude("org/apache/commons/codec/**")
+        exclude("org/apache/commons/lang3/**")
+        exclude("org/apache/commons/beanutils/**")
+        exclude("org/yaml/snakeyaml/**")
+        exclude("javassist/**")
+        exclude("io/micrometer/**")
+        exclude("mozilla/**")
+        exclude("org/publicsuffix/**")
     }
 
-    relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
-    relocate "org.apache.httpcomponents.client5", "io.openlineage.spark.shaded.org.apache.httpcomponents.client5"
-    relocate "javassist", "io.openlineage.spark.shaded.javassist"
-    relocate "org.apache.hc", "io.openlineage.spark.shaded.org.apache.hc"
-    relocate "org.apache.commons.codec", "io.openlineage.spark.shaded.org.apache.commons.codec"
-    relocate "org.apache.commons.lang3", "io.openlineage.spark.shaded.org.apache.commons.lang3"
-    relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
-    relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
-    relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
-    relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
-    relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
-    relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
+//    relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
+//    relocate "org.apache.httpcomponents.client5", "io.openlineage.spark.shaded.org.apache.httpcomponents.client5"
+//    relocate "javassist", "io.openlineage.spark.shaded.javassist"
+//    relocate "org.apache.hc", "io.openlineage.spark.shaded.org.apache.hc"
+//    relocate "org.apache.commons.codec", "io.openlineage.spark.shaded.org.apache.commons.codec"
+//    relocate "org.apache.commons.lang3", "io.openlineage.spark.shaded.org.apache.commons.lang3"
+//    relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
+//    relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
+//    relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
+//    relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
+//    relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
+//    relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -47,6 +47,58 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+task shadowJarWithoutExternalDependencies(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveClassifier.set('without-external-dependencies')
+    configurations = [project.configurations.runtimeClasspath]
+    minimize() {
+        exclude(project(path: ":app"))
+        exclude(project(path: ":shared", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark2"))
+        exclude(project(path: ":spark3", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark31"))
+        exclude(project(path: ":spark32", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark33", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark34", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":snowflake"))
+    }
+
+    dependencies {
+        exclude(dependency("org.slf4j::"))
+        exclude("org/apache/commons/logging/**")
+        exclude("io/openlineage/server/**")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_x86_64.so")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_aarch64.so")
+        exclude("io/openlineage/sql/libopenlineage_sql_java_arm64.dylib")
+        exclude("com/fasterxml/jackson/**")
+        exclude("org/apache/http/**")
+        exclude("org/apache/httpcomponents/client5/**")
+        exclude("com/github/ok2c/hc5/**")
+        exclude("org/apache/hc/**")
+        exclude("org/HdrHistogram/**")
+        exclude("org/LatencyUtils/**")
+        exclude("org/apache/commons/codec/**")
+        exclude("org/apache/commons/lang3/**")
+        exclude("org/apache/commons/beanutils/**")
+        exclude("org/yaml/snakeyaml/**")
+        exclude("javassist/**")
+        exclude("io/micrometer/**")
+        exclude("mozilla/**")
+        exclude("org/publicsuffix/**")
+    }
+
+    manifest {
+        attributes(
+                "Created-By": "Gradle ${gradle.gradleVersion}",
+                "Built-By": System.getProperty("user.name"),
+                "Build-Jdk": System.getProperty("java.version"),
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version
+        )
+    }
+    zip64 true
+}
+
 javadoc {
     options.tags = ["apiNote"]
 }
@@ -168,38 +220,20 @@ shadowJar {
         exclude(dependency("org.slf4j::"))
         exclude("org/apache/commons/logging/**")
         exclude("io/openlineage/server/**")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_x86_64.so")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_aarch64.so")
-        exclude("io/openlineage/sql/libopenlineage_sql_java_arm64.dylib")
-        exclude("com/fasterxml/jackson/**")
-        exclude("org/apache/http/**")
-        exclude("org/apache/httpcomponents/client5/**")
-        exclude("com/github/ok2c/hc5/**")
-        exclude("org/apache/hc/**")
-        exclude("org/HdrHistogram/**")
-        exclude("org/LatencyUtils/**")
-        exclude("org/apache/commons/codec/**")
-        exclude("org/apache/commons/lang3/**")
-        exclude("org/apache/commons/beanutils/**")
-        exclude("org/yaml/snakeyaml/**")
-        exclude("javassist/**")
-        exclude("io/micrometer/**")
-        exclude("mozilla/**")
-        exclude("org/publicsuffix/**")
     }
 
-//    relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
-//    relocate "org.apache.httpcomponents.client5", "io.openlineage.spark.shaded.org.apache.httpcomponents.client5"
-//    relocate "javassist", "io.openlineage.spark.shaded.javassist"
-//    relocate "org.apache.hc", "io.openlineage.spark.shaded.org.apache.hc"
-//    relocate "org.apache.commons.codec", "io.openlineage.spark.shaded.org.apache.commons.codec"
-//    relocate "org.apache.commons.lang3", "io.openlineage.spark.shaded.org.apache.commons.lang3"
-//    relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
-//    relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
-//    relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
-//    relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
-//    relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
-//    relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
+    relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
+    relocate "org.apache.httpcomponents.client5", "io.openlineage.spark.shaded.org.apache.httpcomponents.client5"
+    relocate "javassist", "io.openlineage.spark.shaded.javassist"
+    relocate "org.apache.hc", "io.openlineage.spark.shaded.org.apache.hc"
+    relocate "org.apache.commons.codec", "io.openlineage.spark.shaded.org.apache.commons.codec"
+    relocate "org.apache.commons.lang3", "io.openlineage.spark.shaded.org.apache.commons.lang3"
+    relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
+    relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
+    relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
+    relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
+    relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
+    relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/buildDependencies.sh
+++ b/integration/spark/buildDependencies.sh
@@ -3,3 +3,4 @@ set -x -e
 (cd ../../client/java && ./gradlew publishToMavenLocal)
 (cd ../spark-extension-interfaces && ./gradlew publishToMavenLocal)
 (cd ../sql/iface-java && ./script/compile.sh && ./script/build.sh)
+(cd ../spark-extension-entrypoint && ./gradlew publishToMavenLocal)


### PR DESCRIPTION
This pull request includes changes to the build and publishing processes for the Spark extension interfaces and dependencies. The most important changes involve enabling dependencies within the POM file and adding a new module to the build script.

Changes to build and publishing processes:

* [`integration/spark-extension-interfaces/build.gradle`](diffhunk://#diff-2ba9d328525f62ac2407c189b0a2d8946b173d080aaa1ebed8e0264867fa3d7fL172-R176): Commented out the section that removes dependencies from the POM file to enable them.
* [`integration/spark/buildDependencies.sh`](diffhunk://#diff-dcf2c395241df31774513a6f0e6780132993354a6fd981143d0a94d562cff0f7R6): Added a new module, `spark-extension-entrypoint`, to the build script to publish it to Maven Local.