### PR TITLE
Changing log level from error to warning

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -85,7 +85,9 @@ public class ContextFactory {
   public Optional<ExecutionContext> createSparkSQLExecutionContext(long executionId) {
     QueryExecution queryExecution = SQLExecution.getQueryExecution(executionId);
     if (queryExecution == null) {
-      log.error("Query execution is null: can't emit event for executionId {}", executionId);
+      // We changed this log level from error to warn so it doesn't  mix with other MR and Itapu error logs.
+      // We should investigate if we can act upon this issue. If not, we should change this to debug
+      log.warn("Query execution is null: can't emit event for executionId {}", executionId);
       return Optional.empty();
     }
     SparkSession sparkSession = queryExecution.sparkSession();


### PR DESCRIPTION
This pull request includes a minor change to the logging level in the `createSparkSQLExecutionContext` method of the `ContextFactory` class. The log level was adjusted from error to warning to better manage log output and avoid confusion with other error logs.

Logging level adjustment:

* [`integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java`](diffhunk://#diff-90a996f701b05a7531970b027bd9cbe97c9b1a053fb6579edd00eb1108d45e7aL88-R90): Changed the log level from error to warn in the `createSparkSQLExecutionContext` method to prevent mixing with other error logs and included a comment suggesting further investigation.