### PR TITLE
Removing set of parameters from log related to rdd path

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -134,7 +134,7 @@ public class RddPathUtils {
                   })
               .filter(Objects::nonNull);
         } else {
-          log.warn("Cannot extract path from ParallelCollectionRDD {}", data);
+          log.warn("Cannot extract path from ParallelCollectionRDD");
         }
       } catch (IllegalAccessException | IllegalArgumentException e) {
         log.warn("Cannot read data field from ParallelCollectionRDD {}", rdd);


### PR DESCRIPTION
This pull request includes a minor change to the logging message in the `extract` method of the `RddPathUtils` class. The change removes the variable `data` from the warning log message.

Logging improvements:

* [`integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java`](diffhunk://#diff-3af57652e79aab38070f3f1ed4bc55bb3f74ddf749a1b38ecb352d7d8f7c5d81L137-R137): Updated the warning log message in the `extract` method to remove the `data` variable for cleaner log output.